### PR TITLE
docs: removed broken image links in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,11 +9,6 @@
 This project is a **real-time chat application** built with **React** and **Firebase**, offering secure authentication, instant messaging via Firestore, and seamless deployment with Firebase Hosting.  
 The design is **simple**, **clean**, and focuses on **human-like chat** interaction using purely frontend logic—**no external AI models like ChatGPT used**.
 
-![Home Page](./assets/screenshots/home.png)
-![Login Screen](./assets/screenshots/login.png)
-![Enter chat screen](./assets/screenshots/enter-chat.png)
-![Chat room](./assets/screenshots/chat.png)
-
 ---
 
 <details>


### PR DESCRIPTION
Issue #43 
- Removed the image links in Project Overview section at README
- Result : 
<img width="640" height="341" alt="image" src="https://github.com/user-attachments/assets/29735fe2-eaa2-4470-a79f-01bf99cfb846" />

@Dhruvi-tech 